### PR TITLE
Fix Rust CFG return node

### DIFF
--- a/rust/cfg_builder.py
+++ b/rust/cfg_builder.py
@@ -306,6 +306,8 @@ class CFGBuilder:
         self.cfg.finalblocks.append(self.current_block)
         self.current_block = self.new_block()
 
+    visit_return_expression = visit_return_statement
+
     def visit_break_statement(self, node):
         if self.after_switch_block_stack:
             self.add_exit(self.current_block, self.after_switch_block_stack[-1])


### PR DESCRIPTION
## Summary
- handle `return` expressions in Rust CFG builder

## Testing
- `python - <<'PY'` (generate CFG for binary search snippet)

------
https://chatgpt.com/codex/tasks/task_e_685312103d3883308bcea25a1bfae75e